### PR TITLE
Change Decimals to be Simpler

### DIFF
--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -1,3 +1,3 @@
 export function formatPrice(price: number) {
-  return price.toLocaleString("en-US", { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+  return price.toLocaleString("en-US", { minimumFractionDigits: 0, maximumFractionDigits: 2 });
 }


### PR DESCRIPTION
Just removes the `.00` for these super large numbers. Makes it a bit easier to read.

<img width="796" alt="image" src="https://github.com/user-attachments/assets/0ef9b50b-2017-4074-a95c-2dcd885a1852" />

It still shows for smaller numbers, so we don't lose precision:

<img width="453" alt="image" src="https://github.com/user-attachments/assets/86b2909a-7af7-4eb4-b46f-1cbf8876bda8" />

